### PR TITLE
##### ISSUE TYPE  - Bugfix Pull Request

### DIFF
--- a/templates/cisco_wlc_ssh_show_ap_config_general.template
+++ b/templates/cisco_wlc_ssh_show_ap_config_general.template
@@ -71,4 +71,3 @@ Start
   ^\d+\s+\S+\s+\S+\s+\S+\s+\S+\s*$$
   ^\d+\s+\S+\s+\S+\s+\S+\s+\S+\s*$$
   ^FlexConnect\s+Backup\s+Auth
-  ^. -> Error


### PR DESCRIPTION
##### COMPONENT

cisco_wlc_ssh_show_ap_config_general.template

##### SUMMARY

template rises an error when an empty line exists in command output